### PR TITLE
Expand sidebar header width

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -122,6 +122,7 @@ h6 {
   transition: all 0.5s;
   padding: 15px;
   overflow-y: auto;
+  width: 150px;
 }
 
 @media (max-width: 992px) {
@@ -135,7 +136,7 @@ h6 {
 
 @media (min-width: 992px) {
   #main {
-    margin-left: 100px;
+    margin-left: 150px;
   }
 }
 
@@ -181,11 +182,11 @@ h6 {
 
 @media (min-width: 992px) {
   .nav-menu a {
-    width: 56px;
+    width: 100%;
   }
   .nav-menu a span {
-    display: none;
-    color: #fff;
+    display: inline;
+    color: #45505b;
   }
 }
 


### PR DESCRIPTION
## Summary
- Increase fixed header width to 150px for a more prominent sidebar
- Shift main content accordingly
- Always show navigation labels on desktop by default

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab872e4acc8320806f5d1b2af685cb